### PR TITLE
Implement radius option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,19 @@ generating avatars based on usernames or ids.
 ## Usage
 
 ```typescript
-import { generateSvg } from "https://deno.land/x/avatar@v1.1.0/mod.ts";
+import { generateSvg } from "https://deno.land/x/avatar@v1.2.0/mod.ts";
 
 // Generate an avatar with the default options.
 let avatar = await generateSvg("jimbob");
 
 // Generate an avatar with a custom size.
 avatar = await generateSvg("marysue", { size: 128 });
+
+// Generate an avatar with rounded corners...
+avatar = await generateSvg("billybob", { radius: 10 });
+
+// Or a full circle.
+avatar = await generateSvg("libbymae", { radius: 100, size: 64 });
 ```
 
 ## Credits

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -1,7 +1,8 @@
 import { z } from "https://deno.land/x/zod@v3.22.4/mod.ts";
 
 const validator = z.object({
-  size: z.number().int().min(1).optional().default(64),
+  radius: z.number().int().min(0).default(0),
+  size: z.number().int().min(1).default(64),
 });
 
 type Options = z.input<typeof validator>;

--- a/lib/svg.ts
+++ b/lib/svg.ts
@@ -8,11 +8,17 @@ import type { Options } from "./options.ts";
  */
 async function generate(seed: string, opts?: Options): Promise<string> {
   const key = await keys.generate(seed);
-  const size = options.validate(opts || {}).size;
+  opts = options.validate(opts || {});
 
   return `
-<svg width="${size}" height="${size}" viewBox="0 0 64 64" fill="none" version="1.1" xmlns="http://www.w3.org/2000/svg">
-  ${miniavs.generate(key)}
+<svg width="${opts.size}" height="${opts.size}" viewBox="0 0 64 64" fill="none" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <clipPath id="avatarShape">
+    <rect x="0" y="0" width="64" height="64" rx="${opts.radius}" ry="${opts.radius}" />
+  </clipPath>
+
+  <g clip-path="url(#avatarShape)">
+    ${miniavs.generate(key)}
+  </g>
 </svg>
   `;
 }

--- a/tests/lib/options_test.ts
+++ b/tests/lib/options_test.ts
@@ -6,6 +6,38 @@ import {
 } from "https://deno.land/std@0.208.0/assert/mod.ts";
 import { validate } from "../../lib/options.ts";
 
+Deno.test("validate: radius", async (t) => {
+  await t.step("it accepts a non-negative integer", () => {
+    let opts;
+    opts = validate({ radius: 0 });
+    assertEquals(opts.radius, 0);
+
+    opts = validate({ radius: 1 });
+    assertEquals(opts.radius, 1);
+  });
+
+  await t.step("it defaults to 0 if radius is missing", () => {
+    const opts = validate({});
+    assertEquals(opts.radius, 0);
+  });
+
+  await t.step("it defaults to 0 if radius is undefined", () => {
+    const opts = validate({ radius: undefined });
+    assertEquals(opts.radius, 0);
+  });
+
+  await t.step("it raises if radius is less than zero", () => {
+    assertThrows(() => validate({ radius: -1 }));
+  });
+
+  await t.step("it raises if radius is not an integer", () => {
+    assertThrows(() => validate({ radius: 2.1 }));
+    assertThrows(() => validate({ radius: "2" }));
+    assertThrows(() => validate({ radius: {} }));
+    assertThrows(() => validate({ radius: [] }));
+  });
+});
+
 Deno.test("validate: size", async (t) => {
   await t.step("it accepts a valid size", () => {
     const opts = validate({ size: 128 });

--- a/tests/lib/svg_test.ts
+++ b/tests/lib/svg_test.ts
@@ -35,6 +35,24 @@ Deno.test("svg", async (t) => {
     assert(regex.test(svg));
   });
 
+  await t.step(
+    "it generates an svg clip path with the default radius",
+    async () => {
+      const regex = new RegExp('<rect [^>]+ rx="0" ry="0"', "is");
+      const svg = (await generate("test")).trim();
+      assert(regex.test(svg));
+    },
+  );
+
+  await t.step(
+    "it generates an svg clip path with the given radius",
+    async () => {
+      const regex = new RegExp('<rect [^>]+ rx="10" ry="10"', "is");
+      const svg = (await generate("test", { radius: 10 })).trim();
+      assert(regex.test(svg));
+    },
+  );
+
   // keys_test.ts covers the seed validation, this is just a sanity check.
   await t.step("it raises if the seed is invalid", () => {
     assertRejects(() => generate(1));


### PR DESCRIPTION
Add support for a `radius` option. This allows the user to create an SVG with rounded corners. Passing a `radius >= size / 2` creates a round SVG.

Closes #3.